### PR TITLE
Improved queue system

### DIFF
--- a/deletion.py
+++ b/deletion.py
@@ -1,0 +1,14 @@
+from discord.message import Message
+
+class Deletion:
+    def __init__(self, message: Message, remainingTime: int):
+        self.message = message
+        self.remainingTime = remainingTime
+    
+    async def update(self):
+        self.remainingTime = self.remainingTime - 1
+        if (self.remainingTime <= 0):
+            await self.message.delete()
+            return True
+        else:
+            return False

--- a/deletion.py
+++ b/deletion.py
@@ -8,7 +8,11 @@ class Deletion:
     async def update(self):
         self.remainingTime = self.remainingTime - 1
         if (self.remainingTime <= 0):
-            await self.message.delete()
-            return True
+            try:
+                await self.message.delete()
+            except Exception as exception:
+                print(f"Error: {exception}")
+            finally:
+                return True
         else:
             return False

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import random
 import requests
 import sys
 import threading
+import time
 import yaml
 
 sys.path.append("./objection_engine")
@@ -295,6 +296,7 @@ def renderThread():
 async def backgroundRenderer():
     global renderQueue
     while True:
+        time.sleep(2)
         try:
             for render in renderQueue:
                 if render.getState() == State.QUEUED:
@@ -309,6 +311,7 @@ async def backgroundRenderer():
             print(f"Error: {exception}")
 
 backgroundThread = threading.Thread(target=renderThread)
+backgroundThread.name = "RenderThread"
 backgroundThread.start()
 
 courtBot.run(token)

--- a/main.py
+++ b/main.py
@@ -69,8 +69,10 @@ async def changeActivity(newActivityText):
         print(f"Error: {exception}")
 
 def addToDeletionQueue(message: discord.Message):
-    newDeletion = Deletion(message, int(deletionDelay))
-    deletionQueue.append(newDeletion)
+    # Only if deletion delay is grater than 0, add it to the deletionQueue.
+    if int(deletionDelay) > 0:
+        newDeletion = Deletion(message, int(deletionDelay))
+        deletionQueue.append(newDeletion)
 
 @courtBot.event
 async def on_message(message):

--- a/main.py
+++ b/main.py
@@ -1,127 +1,266 @@
-import re
-import random
-import os
-import sys
-sys.path.insert(0, './objection_engine')
-import yaml
+import asyncio
 import discord
+import os
+import random
+import requests
+import sys
+import threading
+import yaml
+
+sys.path.append("./objection_engine")
+
+from deletion import Deletion
 from discord.ext import commands, tasks
 from message import Message
-import threading
-import asyncio
-from objection_engine.renderer import render_comment_list
 from objection_engine.beans.comment import Comment
+from objection_engine.renderer import render_comment_list
+from render import Render, State
 from typing import List
-import requests
 
-currentActivity = ""
-
-# queue Lists
-videoRenderQueue = []
-messageQueue = []
+# Global Variables:
+currentActivityText = ""
+renderQueue = []
 deletionQueue = []
 
-if not os.path.isfile("config.yaml"):
-    sys.exit("'config.yaml' is missing!")
-else:
-    with open("config.yaml") as file:
-        configuration = yaml.load(file, Loader=yaml.FullLoader)
-        token = configuration["token"].strip()
-        prefix = configuration["prefix"].strip()
-        deletionDelay = configuration["deletionDelay"].strip()
-
-if not token:
-    sys.exit("The 'token' is missing in the 'config.yaml' file!")
-if not prefix:
-    sys.exit("The 'prefix' is missing in the 'config.yaml' file!")
-if not deletionDelay:
-    sys.exit("The 'deletionDelay' is missing in the 'config.yaml' file!")
-
-client = commands.AutoShardedBot(command_prefix=prefix, intents=discord.Intents.default())
-
-# Removing default help command
-client.remove_command("help")
-
-async def changeActivity(text):
+def loadConfig():
     try:
-        global currentActivity
+        with open("config.yaml") as file:
+            config = yaml.load(file, Loader=yaml.FullLoader)
+            global token, prefix, deletionDelay
 
-        if currentActivity == text:
+            token = config["token"].strip()
+            if not token:
+                raise Exception("The 'token' field is missing in the config file (config.yaml)!")
+
+            prefix = config["prefix"].strip()
+            if not prefix:
+                raise Exception("The 'prefix' field is missing in the config file (config.yaml)!")
+
+            deletionDelay = config["deletionDelay"].strip()
+            if not deletionDelay:
+                raise Exception("The 'deletionDelay' field is missing in the config file (config.yaml)!")
+            
+            return True
+    except KeyError as keyErrorException:
+        print(f"The mapping key {keyErrorException} is missing in the config file (config.yaml)!")
+    except Exception as exception:
+        print(exception)
+        return False
+
+if not loadConfig():
+    exit()
+
+courtBot = commands.AutoShardedBot(command_prefix=prefix, Intents=discord.Intents.default())
+# Default 'help' command is removed, we will make our own
+courtBot.remove_command("help")
+currentActivityText = f"{prefix}help"
+
+async def changeActivity(newActivityText):
+    try:
+        global currentActivityText
+        if currentActivityText == newActivityText:
             return
-        else:    
-            activity = discord.Game(text)
-            await client.change_presence(activity=activity)
-            currentActivity = text
-            print(f"Activity changed to {currentActivity}")
-    except Exception as e:
-        pass
+        else:
+            newActivity = discord.Game(newActivityText)
+            await courtBot.change_presence(activity=newActivity)
+            currentActivityText = newActivityText
+            print(f"Activity was changed to {currentActivityText}")
+    except Exception as exception:
+        print(f"Error: {exception}")
 
-@client.event
-async def on_ready():
-    messageLoop.start()
-    print("Bot is ready!")
-    print(f"Logged in as {client.user.name}#{client.user.discriminator} ({client.user.id})")
+def addToDeletionQueue(message: discord.Message):
+    newDeletion = Deletion(message, int(deletionDelay))
+    deletionQueue.append(newDeletion)
 
-@client.event
+@courtBot.event
 async def on_message(message):
-    # Ignore message if the author is a bot (or the client's logged user)
-    if message.author is client.user or message.author.bot:
+    if message.author is courtBot.user or message.author.bot:
         return
     if message.channel.type is discord.ChannelType.private:
-        embedResponse = discord.Embed(description="I won't process any messages via PM.\nIf you have any problem please go to [the support server](https://discord.gg/pcS4MPbRDU).", color=0xff0000)
+        embedResponse = discord.Embed(description="I won't process any messages via PM.\nIf you have any problems, please go to [the support server](https://discord.gg/pcS4MPbRDU).", color=0xff0000)
         await message.channel.send(embed=embedResponse)
         return
+    await courtBot.process_commands(message)
 
-    await client.process_commands(message)
-
-@client.command()
+@courtBot.command()
 async def help(context):
     dummyAmount = random.randint(2, 150)
-    embedHelp = discord.Embed(description="Discord bot that turns message chains into ace attorney scenes.", color=0x3366CC, footer="Do not include these symbols (\"<\" and \">\") when using this command")
-    embedHelp.set_author(name=client.user.name, icon_url=client.user.avatar_url)
-    embedHelp.add_field(name="How to use?", value=f"`{prefix}render <number_of_messages>`", inline=False)
-    embedHelp.add_field(name="Example", value=f"Turn the last {dummyAmount} messages into an ace attorney scene: `{prefix}render {dummyAmount}`", inline=False)
-    embedHelp.add_field(name="Starting message", value="By default the bot will load the specified number of messages from the last message (before using the command) going backwards, if you want the message count to start from another message, reply to it when using the command.", inline=False)
-    await context.send(embed=embedHelp)
+    helpEmbed = discord.Embed(description="Discord bot that turns message chains into ace attorney scenes.\nIf you have any problems, please go to [the support server](https://discord.gg/pcS4MPbRDU).", color=0x3366CC, footer="Do not include these symbols (\"<\" and \">\") when using this command")
+    helpEmbed.set_author(name=courtBot.user.name, icon_url=courtBot.user.avatar_url)
+    helpEmbed.add_field(name="How to use?", value=f"`{prefix}render <number_of_messages>`", inline=False)
+    helpEmbed.add_field(name="Example", value=f"Turn the last {dummyAmount} messages into an ace attorney scene: `{prefix}render {dummyAmount}`", inline=False)
+    helpEmbed.add_field(name="Starting message", value="By default the bot will load the specified number of messages from the last message (before using the command) going backwards, if you want the message count to start from another message, reply to it when using the command.", inline=False)
+    helpMessage = await context.send(embed=helpEmbed)
+    addToDeletionQueue(helpMessage)
 
-@client.command()
-async def render(context, numberOfMessages):
+@courtBot.command()
+async def render(context, numberOfMessages: int):
+    global renderQueue
     feedbackMessage = await context.send(content="`Fetching messages...`")
-    if numberOfMessages.isdigit() and int(numberOfMessages) in range (1, 151):
-        messages = []
-        async for message in context.channel.history(limit=int(numberOfMessages), oldest_first=False, before=context.message.reference.resolved if context.message.reference else context.message):
-            msg = Message(message)
-            if msg.text.strip():
-                messages.insert(0, msg.to_Comment())
-
-        if (len(messages) >= 1): 
-            
-            await feedbackMessage.edit(content="`Fetching messages... Done!`\n`Queued, please wait...`\n")
-            videoRender = (False, message.id, messages, "")
-            videoRenderQueue.append(videoRender)
-            newMessage = (message, context, feedbackMessage.id)
-            messageQueue.append(newMessage)
-        else:
-            embedResponse = discord.Embed(description="There should be at least one person in the conversation", color=0xff0000)
-            await feedbackMessage.edit(content="", embed=embedResponse, mention_author=False)
-    else:
-        embedResponse = discord.Embed(description="Number of messages must be between 1 and 150", color=0xff0000)
-        await feedbackMessage.edit(content="", embed=embedResponse, mention_author=False)
-        return
-
-def clean(thread: List[Comment], output_filename):
     try:
-        os.remove(output_filename)
-    except Exception as second_e:
-        print(second_e)
+        if not (numberOfMessages in range(1, 151)):
+            raise Exception("Number of messages must be between 1 and 150.")
+
+        # baseMessage is the message from which the specified number of messages will be fetch, not including itself
+        baseMessage = context.message.reference.resolved if context.message.reference else context.message
+        courtMessages = []
+        discordMessages = []
+
+        # If the render command was executed within a reply (baseMessage and context.Message aren't the same), we want
+        # to append the message the user replied to (baseMessage) to the 'discordMessages' list and substract 1 from
+        # 'numberOfMessages' that way we are taking the added baseMessage into consideration and avoid getting 1 extra message)
+        if not baseMessage.id == context.message.id:
+            numberOfMessages = numberOfMessages - 1
+            discordMessages.append(baseMessage)
+
+        async for discordMessage in context.channel.history(limit=numberOfMessages, oldest_first=False, before=baseMessage):
+            message = Message(discordMessage)
+            if message.text.strip():
+                courtMessages.insert(0, message.to_Comment())
+
+        if len(courtMessages) < 1:
+            raise Exception("There should be at least one person in the conversation.")
+
+        newRender = Render(State.QUEUED, context, feedbackMessage, courtMessages)
+        renderQueue.append(newRender)
+
+    except Exception as exception:
+        exceptionEmbed = discord.Embed(description=exception, color=0xff0000)
+        await feedbackMessage.edit(content="", embed=exceptionEmbed)
+        addToDeletionQueue(feedbackMessage)
+
+@tasks.loop(seconds=1)
+async def deletionQueueLoop():
+    global deletionQueue
+    deletionQueueSize = len(deletionQueue)
+    # Delete message and remove from queue if remaining time is less than (or equal to) 0
+    if deletionQueueSize > 0:
+        for index in reversed(range(deletionQueueSize)):
+            if await deletionQueue[index].update():
+                deletionQueue.pop(index)
+
+@tasks.loop(seconds=1)
+async def renderQueueLoop():
+    global renderQueue
+    renderQueueSize = len(renderQueue)
+    await changeActivity(f"{prefix}help | queue: {renderQueueSize}")
+    for positionInQueue, render in enumerate(iterable=renderQueue):
+        try:
+            if render.getState() == State.QUEUED:
+                newFeedback = f"""
+                `Fetching messages... Done!`
+                `Position in the queue: #{(positionInQueue)}`
+                """
+                await render.updateFeedback(newFeedback)
+
+            if render.getState() == State.INPROGRESS:
+                newFeedback = f"""
+                `Fetching messages... Done!`
+                `Your video is being generated...`
+                """
+                await render.updateFeedback(newFeedback)
+
+            if render.getState() == State.FAILED:
+                newFeedback = f"""
+                `Fetching messages... Done!`
+                `Your video is being generated... Failed!`
+                """
+                await render.updateFeedback(newFeedback)
+                render.setState(State.DONE)
+
+            if render.getState() == State.RENDERED:
+
+                
+                newFeedback = f"""
+                `Fetching messages... Done!`
+                `Your video is being generated... Done!`
+                `Uploading file to Discord...`
+                """
+                await render.updateFeedback(newFeedback)
+
+                # If the file size is lower than the maximun file size allowed in this guild, upload it to Discord
+                fileSize = os.path.getsize(render.getOutputFilename())
+                if fileSize < render.getContext().channel.guild.filesize_limit:
+                    await render.getContext().send(file=discord.File(render.getOutputFilename()))
+                    render.setState(State.DONE)
+                    newFeedback = f"""
+                    `Fetching messages... Done!`
+                    `Your video is being generated... Done!`
+                    `Uploading file to Discord... Done!`
+                    """
+                    await render.updateFeedback(newFeedback)
+                else:
+                    try:
+                        newFeedback = f"""
+                        `Fetching messages... Done!`
+                        `Your video is being generated... Done!`
+                        `Video file too big for you server! {round(fileSize/1000000, 2)} MB`
+                        `Trying to upload file to an external server...`
+                        """
+                        await render.updateFeedback(newFeedback)
+                        with open(render.getOutputFilename(), 'rb') as videoFile:
+                            files = {'files[]': (render.getOutputFilename(), videoFile)}
+                            response = requests.post('https://tmp.ninja/upload.php?output=text', files=files).content.decode("utf-8").strip()
+                            newFeedback = f"""
+                            `Fetching messages... Done!`
+                            `Your video is being generated... Done!`
+                            `Video file too big for you server! {round(fileSize/1000000, 2)} MB`
+                            `Trying to upload file to an external server... Done!`
+                            """
+                            await render.updateFeedback(newFeedback)
+                            await render.getContext().send(content=f"{response}\n_This video will be deleted in 48 hours_")
+                            render.setState(State.DONE)
+
+                    except Exception as exception:
+                        newFeedback = f"""
+                        `Fetching messages... Done!`
+                        `Your video is being generated... Done!`
+                        `Video file too big for you server! {round(fileSize/1000000, 2)} MB`
+                        `Trying to upload file to an external server... Failed!`
+                        """
+                        await render.updateFeedback(newFeedback)
+                        exceptionEmbed = discord.Embed(description=exception, color=0xff0000)
+                        exceptionMessage = await render.getContext().send(embed=exceptionEmbed)
+                        addToDeletionQueue(exceptionMessage)
+                        render.setState(State.DONE)
+
+        except Exception as exception:
+            print(f"Error: {exception}")
+            try:
+                render.setState(State.DONE)
+            except:
+                pass
+        finally:
+            if render.getState() == State.DONE:
+                clean(render.getMessages(), render.getOutputFilename())
+                addToDeletionQueue(render.getFeedbackMessage())
+
+    # Remove from queue if state is DONE
+    if renderQueueSize > 0:
+        for index in reversed(range(renderQueueSize)):
+            if renderQueue[index].getState() == State.DONE:
+                renderQueue.pop(index)
+
+@courtBot.event
+async def on_ready():
+    print("Bot is ready!")
+    print(f"Logged in as {courtBot.user.name}#{courtBot.user.discriminator} ({courtBot.user.id})")
+    renderQueueLoop.start()
+    deletionQueueLoop.start()
+
+def clean(thread: List[Comment], filename):
+    try:
+        os.remove(filename)
+    except Exception as exception:
+        print(exception)
     try:
         for comment in thread:
             if (comment.evidence_path is not None):
-                os.remove(comment.evidence_path)
-    except Exception as second_e:
-        print(second_e)
+                os.remove(comment.evidente_path)
+    except Exception as exception:
+        print(exception)
 
-def rendererCall():
+def renderThread():
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
@@ -129,125 +268,23 @@ def rendererCall():
     loop.close()
 
 async def backgroundRenderer():
+    global renderQueue
     while True:
         try:
-            length = len(videoRenderQueue)
-            if length <= 0:
-                continue
-            for index in range(length):
-                videoRender = videoRenderQueue[index]
-                if videoRender[0] == False:
+            for render in renderQueue:
+                if render.getState() == State.QUEUED:
+                    render.setState(State.INPROGRESS)
                     try:
-                        output_filename = str(videoRender[1]) + '.mp4'
-                        render_comment_list(videoRender[2], output_filename)
+                        render_comment_list(render.getMessages(), render.getOutputFilename())
+                        render.setState(State.RENDERED)
+                    except Exception as exception:
+                        print(f"Error: {exception}")
+                        render.setState(State.FAILED)
+        except Exception as exception:
+            print(f"Error: {exception}")
 
-                        newVideoRenderTuple = (True, videoRender[1], videoRender[2], output_filename)
-                        videoRenderQueue.remove(videoRender)
-                        videoRenderQueue.insert(index, newVideoRenderTuple)
-                    except Exception as e:
-                        newVideoRenderTuple = (True, videoRender[1], videoRender[2], f"failed {e}")
-                        videoRenderQueue.remove(videoRender)
-                        videoRenderQueue.insert(index, newVideoRenderTuple)
-        except Exception as e:
-            pass
+backgroundThread = threading.Thread(target=renderThread)
+backgroundThread.start()
 
-@tasks.loop(seconds=1)
-async def messageLoop():
-    await changeActivity(f"{prefix}help | queue: {len(messageQueue)}")
-    try:
-        length = len(messageQueue)
-        if length > 0:
-            for index in range(length-1, -1, -1):
-                currentMessage = messageQueue[index]
-                message = currentMessage[0]
-                context = currentMessage[1]
-                feedbackMessageId = currentMessage[2]
-                feedbackMessage = await context.channel.fetch_message(feedbackMessageId)
-
-                if index == 0:
-                    # Updates message (only if it hasn't already been updated) to reflect that it's first in the queue. 
-                    newContent = "`Fetching messages... Done!`\n`Your video is being generated...`\n"
-                    if feedbackMessage.content != newContent:
-                        await feedbackMessage.edit(content = newContent)
-                    
-                for videoRender in videoRenderQueue:
-                    if videoRender[1] == message.id:
-                        if videoRender[0]:
-                            fileSizeBytes = 0
-                            try:
-                                if re.match("^failed\s", videoRender[3]):
-                                    await feedbackMessage.edit(content=f"`Fetching messages... Done!`\n`Your video is being generated... Failed!`")
-                                    error = re.sub("^failed", "", videoRender[3])
-                                    embedResponse = discord.Embed(description=f"Error: {error}", color=0xff0000)
-                                    errorMessage = await context.send(embed=embedResponse)
-                                    messageToBeDeleted = (context, errorMessage.id, int(deletionDelay))
-                                    deletionQueue.append(messageToBeDeleted)
-                                else:
-                                    await feedbackMessage.edit(content=f"`Fetching messages... Done!`\n`Your video is being generated... Done!`\n`Uploading file to Discord...`")
-                                    fileSizeBytes = round((os.path.getsize(videoRender[3])/1000000), 2)
-                                    if (fileSizeBytes) >= 8:
-                                        raise Exception()
-                                    else:
-                                        await context.send(file=discord.File(videoRender[3]))
-                                        await feedbackMessage.edit(content=f"`Fetching messages... Done!`\n`Your video is being generated... Done!`\n`Uploading file to Discord... Done!`")
-                            except Exception as e:
-                                try:
-                                    try:
-                                        if (fileSizeBytes) >= 8:
-                                            await feedbackMessage.edit(content=f"`Fetching messages... Done!`\n`Your video is being generated... Done!`\n`Video file too big for discord! ({fileSizeBytes} MB)`\n`Trying to upload file to an external server...`")
-                                            with open(videoRender[3], 'rb') as videoFile:
-                                                files = {'files[]': (videoRender[3], videoFile)}
-                                                response = requests.post('https://tmp.ninja/upload.php?output=text', files=files)
-                                            await feedbackMessage.edit(content=f"`Fetching messages... Done!`\n`Your video is being generated... Done!`\n`Video file too big for discord! ({fileSizeBytes} MB)`\n`Trying to upload file to an external server... Done!`")
-                                            url = response.content.decode("utf-8").strip()
-                                            await context.send(content=f"{url}\n_This video will be deleted in 48 hours_")
-                                        else:
-                                            raise Exception(e)
-                                    except Exception as e:
-                                        await feedbackMessage.edit(content=f"`Fetching messages... Done!`\n`Your video is being generated... Done!`\n`Video file too big for discord! ({fileSizeBytes} MB)`\n`Trying to upload file to an external server... Failed!`")
-                                        embedResponse = discord.Embed(description=f"Error: {e}", color=0xff0000)
-                                        errorMessage = await context.send(embed=embedResponse)
-                                        messageToBeDeleted = (context, errorMessage.id, int(deletionDelay))
-                                        deletionQueue.append(messageToBeDeleted)
-                                except Exception:
-                                    pass
-                            
-                            # The "feedback" message is added to the deletion queue
-                            messageToBeDeleted = (context, feedbackMessageId, int(deletionDelay))
-                            deletionQueue.append(messageToBeDeleted)
-
-                            # clean function called
-                            clean(videoRender[2], videoRender[3])
-
-                            # both the video and the message are removed from the queue, once posted/failed
-                            videoRenderQueue.remove(videoRender)
-                            messageQueue.remove(currentMessage)
-                            
-                            break
-    except Exception as e:
-        pass
-    try:
-        if int(deletionDelay) > 0:
-            length = len(deletionQueue)
-            if length > 0:
-                for index in range(length-1, -1, -1):
-                    if (index > len(deletionQueue)-1):
-                        break
-                    currentMessage = deletionQueue[index]
-                    newMessageTuple = (currentMessage[0], currentMessage[1], int(currentMessage[2])-1)
-                    deletionQueue.remove(currentMessage)
-                    if (int(newMessageTuple[2]) > 0):
-                        deletionQueue.insert(index, newMessageTuple)
-                    else:
-                        message = await currentMessage[0].channel.fetch_message(currentMessage[1])
-                        await message.delete()
-                        index = index - 1
-    except Exception as e:
-        pass
-                    
-
-th = threading.Thread(target=rendererCall)
-th.start()
-
-client.run(token)
-th.join()
+courtBot.run(token)
+backgroundThread.join()

--- a/main.py
+++ b/main.py
@@ -205,6 +205,8 @@ async def renderQueueLoop():
                 """
                 await render.updateFeedback(newFeedback)
 
+                render.setState(State.UPLOADING)
+
                 # If the file size is lower than the maximun file size allowed in this guild, upload it to Discord
                 fileSize = os.path.getsize(render.getOutputFilename())
                 if fileSize < render.getContext().channel.guild.filesize_limit:

--- a/main.py
+++ b/main.py
@@ -225,7 +225,7 @@ async def renderQueueLoop():
                         await render.updateFeedback(newFeedback)
                         with open(render.getOutputFilename(), 'rb') as videoFile:
                             files = {'files[]': (render.getOutputFilename(), videoFile)}
-                            response = requests.post('https://tmp.ninja/upload.php?output=text', files=files).content.decode("utf-8").strip()
+                            response = requests.post('https://uguu.se/upload.php?output=text', files=files).content.decode("utf-8").strip()
                             newFeedback = f"""
                             `Fetching messages... Done!`
                             `Your video is being generated... Done!`

--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import asyncio
 import discord
 import os
 import random
@@ -289,13 +288,6 @@ def clean(thread: List[Comment], filename):
         print(f"Error: {exception}")
 
 def renderThread():
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-
-    loop.run_until_complete(backgroundRenderer())
-    loop.close()
-
-async def backgroundRenderer():
     global renderQueue
     while True:
         time.sleep(2)
@@ -312,8 +304,7 @@ async def backgroundRenderer():
         except Exception as exception:
             print(f"Error: {exception}")
 
-backgroundThread = threading.Thread(target=renderThread)
-backgroundThread.name = "RenderThread"
+backgroundThread = threading.Thread(target=renderThread, name="RenderThread")
 backgroundThread.start()
 
 courtBot.run(token)

--- a/main.py
+++ b/main.py
@@ -111,7 +111,7 @@ async def queue(context):
             except: pass
             try: queue.write(f"Channel: #{render.getFeedbackMessage().channel.name}\n")
             except: pass
-            try: queue.write(f"State: #{render.getStateString()}\n")
+            try: queue.write(f"State: {render.getStateString()}\n")
             except: pass
     await context.send(file=discord.File(filename))
     clean([], filename)

--- a/render.py
+++ b/render.py
@@ -11,7 +11,8 @@ class State(Enum):
     INPROGRESS = 1
     FAILED = 2
     RENDERED = 3
-    DONE = 4
+    UPLOADING = 4
+    DONE = 5
 
 class Render:
     def __init__(self, state: State, discordContext: Context, feedbackMessage: Message, messages: List[Comment]):
@@ -30,6 +31,8 @@ class Render:
             return "Failed"
         if self.state == State.RENDERED:
             return "Rendered"
+        if self.state == State.UPLOADING:
+            return "Uploading"
         if self.state == State.DONE:
             return "Done"
 

--- a/render.py
+++ b/render.py
@@ -23,15 +23,15 @@ class Render:
 
     def getStateString(self):
         if self.state == State.QUEUED:
-            return "QUEUED"
+            return "Queued"
         if self.state == State.INPROGRESS:
-            return "INPROGRESS"
+            return "In progress"
         if self.state == State.FAILED:
-            return "FAILED"
+            return "Failed"
         if self.state == State.RENDERED:
-            return "RENDERED"
+            return "Rendered"
         if self.state == State.DONE:
-            return "DONE"
+            return "Done"
 
     def getState(self):
         return self.state

--- a/render.py
+++ b/render.py
@@ -1,0 +1,44 @@
+import textwrap
+
+from discord.ext.commands import Context
+from discord.message import Message
+from enum import Enum
+from objection_engine.beans.comment import Comment
+from typing import List
+
+class State(Enum):
+    QUEUED = 0
+    INPROGRESS = 1
+    FAILED = 2
+    RENDERED = 3
+    DONE = 4
+
+class Render:
+    def __init__(self, state: State, discordContext: Context, feedbackMessage: Message, messages: List[Comment]):
+        self.state = state
+        self.discordContext = discordContext
+        self.feedbackMessage = feedbackMessage
+        self.messages = messages
+        self.outputFilename = f"{str(discordContext.message.id)}.mp4"
+
+    def getState(self):
+        return self.state
+        
+    def getContext(self):
+        return self.discordContext
+
+    def getFeedbackMessage(self):
+        return self.feedbackMessage
+
+    def getMessages(self):
+        return self.messages
+
+    def getOutputFilename(self):
+        return self.outputFilename
+
+    def setState(self, state: State):
+        self.state = state
+        
+    async def updateFeedback(self, newContent: str):
+        if self.feedbackMessage.content != textwrap.dedent(newContent):
+            await self.feedbackMessage.edit(content=textwrap.dedent(newContent))

--- a/render.py
+++ b/render.py
@@ -40,5 +40,11 @@ class Render:
         self.state = state
         
     async def updateFeedback(self, newContent: str):
-        if self.feedbackMessage.content != textwrap.dedent(newContent):
-            await self.feedbackMessage.edit(content=textwrap.dedent(newContent))
+        try:
+            # If it's unable to edit/get the feedback message, that means that it no longer exists
+            if self.feedbackMessage.content != textwrap.dedent(newContent):
+                await self.feedbackMessage.edit(content=textwrap.dedent(newContent))
+        except Exception as exception:
+            # If it doesn't exists, we will repost it.
+            print(f"Error: {exception}")
+            self.feedbackMessage = await self.discordContext.send(content=textwrap.dedent(newContent))

--- a/render.py
+++ b/render.py
@@ -21,6 +21,18 @@ class Render:
         self.messages = messages
         self.outputFilename = f"{str(discordContext.message.id)}.mp4"
 
+    def getStateString(self):
+        if self.state == State.QUEUED:
+            return "QUEUED"
+        if self.state == State.INPROGRESS:
+            return "INPROGRESS"
+        if self.state == State.FAILED:
+            return "FAILED"
+        if self.state == State.RENDERED:
+            return "RENDERED"
+        if self.state == State.DONE:
+            return "DONE"
+
     def getState(self):
         return self.state
         


### PR DESCRIPTION
- Improved readability.
- imports are sorted alphabetically.
- Removed the use of regular expressions in main.py.
- Queue should work as expected now, some items were not being removed correctly.
- videoRenderQueue and messageQueue were merge into a single renderQueue.
- Feedback message will inform the user their position in the queue.
[Example](https://user-images.githubusercontent.com/66618574/121196920-1ae1f980-c82e-11eb-809f-04d39b962e82.png)
![sample](https://user-images.githubusercontent.com/66618574/121193417-0ea86d00-c82b-11eb-8a43-a8c400cd66cf.png)
- Max fille size now depends on the guild where the render command was executed in.
_(Instead of being hard-coded to 8 MB)_
- Both render queue and deletion queue use a class now instead of a tuple.
- Added link to support server on help embed.
- Now help messages are added to the deletion queue.
- Improved error handling.
- Iterations are done backwards when deleting items from list to prevent out of bounds indexes.
- Added a new command (queue) **ONLY THE BOT OWNER IS ABLE TO USE THIS COMMAND**.
The bot will upload a .txt with information about the queue, if the user who excecuted the command is not the bot owner, the bot will simply ignore them.
_(This was added as a way to gather more information if some items get stuck in the queue again, just in case it keeps happening)._
![queue command](https://user-images.githubusercontent.com/66618574/121489780-a58f3980-c991-11eb-9783-885bdf7bf25d.png)
- deletion.py: If the message no longer exists when it tries to delete it, just return True as if it was deleted succesfully.
- render.py: Added getStateString function, used by queue command.
- render.py: If the feedback message was deleted, updateFeedback() raised an Exception and made the render act as if it had failed (in main.py's renderQueueLoop()). This scenario is now handled by sending a new feedback messages if the one saved no longer exists.
- Changed tmp.ninja to uguu.se (for external uploads) the later is more reliable.